### PR TITLE
Update package for latest Atom APIs (atom-space-pen-views)

### DIFF
--- a/lib/mobile-preview-editor-view.coffee
+++ b/lib/mobile-preview-editor-view.coffee
@@ -1,4 +1,4 @@
-{$, EditorView, View} = require 'atom-space-pen-views'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
 MobilePreviewView = require './mobile-preview-view'
 
 
@@ -8,7 +8,7 @@ class MobilePreviewEditorView extends View
   mobilePreviewView: null
   @content: ->
     @div class: 'overlay mobile-preview from-top mini', =>
-      @subview 'selectEditor', new EditorView(mini: true)
+      @subview 'selectEditor', new TextEditorView(mini: true)
       @div class: 'pull-left', =>
         @button class: 'btn btn-xs', outlet: 'currentButton', 'Current File'
       @div class: 'pull-right', =>

--- a/lib/mobile-preview-editor-view.coffee
+++ b/lib/mobile-preview-editor-view.coffee
@@ -1,4 +1,4 @@
-{$, EditorView, View} = require 'atom'
+{$, EditorView, View} = require 'atom-space-pen-views'
 MobilePreviewView = require './mobile-preview-view'
 
 

--- a/lib/mobile-preview-view.coffee
+++ b/lib/mobile-preview-view.coffee
@@ -1,4 +1,4 @@
-{View} = require 'atom'
+{View} = require 'atom-space-pen-views'
 
 module.exports =
 class MobilePreviewView extends View

--- a/package.json
+++ b/package.json
@@ -12,5 +12,7 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "atom-space-pen-views": "^2.0.3"
+  }
 }


### PR DESCRIPTION
Fixes the issue where the content and cursor of the mini editor used for entering a URL to preview or selecting the current file is invisible. Also helps get the package ready for 1.0.
